### PR TITLE
fix: use a PR to update the generated docs

### DIFF
--- a/.github/workflows/documentation_generation.yaml
+++ b/.github/workflows/documentation_generation.yaml
@@ -15,3 +15,5 @@ jobs:
         fetch-depth: 0
     - name: Generate Actions Documentation
       uses: ./github-actions
+      with:
+        github_token: '${{ github.token }}'

--- a/github-actions/action.yml
+++ b/github-actions/action.yml
@@ -23,6 +23,18 @@ inputs:
     required: false
     default: |-
       third-party/**/*
+  branch:
+    description: |-
+      The branch name used by the bot to be pushed at the origin.
+    default: generated-doc-github-actions
+  commit_title:
+    description: |-
+      The title of the commit with the generated doc. The PR will also use this
+      title.
+    default: 'doc: auto-generated GH Actions README.md'
+  github_token:
+    description: The GitHub repository token.
+    required: true
 outputs: {}
 runs:
   using: composite
@@ -45,8 +57,18 @@ runs:
         git config user.name github-actions
         git config user.email github-actions@github.com
 
+        git checkout -B "${BRANCH}"
         git add ${{ steps.modified_files.outputs.files }}
-        git commit --message 'doc: auto-generated GH Actions README.md'
-        git push
+        git commit --message "${COMMIT_TITLE}"
+        git push --force-with-lease --set-upstream origin "${BRANCH}"
+
+        '${{ github.action_path }}/open_pr.sh'
       fi
+    env:
+      GITHUB_TOKEN: '${{ inputs.github_token }}'
+      REPOSITORY: '${{ github.repository }}'
+      REPOSITORY_OWNER: '${{ github.repository_owner }}'
+      BRANCH: '${{ inputs.branch }}'
+      COMMIT_TITLE: '${{ inputs.commit_title }}'
+      BASE_REF: '${{ github.ref }}'
     shell: bash

--- a/github-actions/action.yml
+++ b/github-actions/action.yml
@@ -31,7 +31,7 @@ inputs:
     description: |-
       The title of the commit with the generated doc. The PR will also use this
       title.
-    default: 'doc: auto-generated GH Actions README.md'
+    default: 'doc: auto-generated GitHub Actions README.md'
   github_token:
     description: The GitHub repository token.
     required: true

--- a/github-actions/generate.rb
+++ b/github-actions/generate.rb
@@ -51,8 +51,8 @@ Dir.chdir git_root.chomp do
         inputs.each do |name, input|
           description = input["description"].gsub(/\s+/, ' ')
           required = input["required"]
-          default = input["default"]
-          f << "| #{name} | #{description} | #{required} | `#{default}` |\n"
+          default = "`#{input["default"]}`" unless input["default"].nil? || input["default"].empty?
+          f << "| #{name} | #{description} | #{required} | #{default} |\n"
         end
       else
         f << "This action has no inputs.\n"

--- a/github-actions/open_pr.sh
+++ b/github-actions/open_pr.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+prs=$(
+  curl \
+    --fail \
+    --request GET \
+    --header "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/repos/${REPOSITORY}/pulls?state=open&head=${REPOSITORY_OWNER}:${BRANCH}" \
+    | jq -r length
+)
+
+if [ "${prs}" -gt 0 ]; then
+  >&2 echo "Pull request already exists for '${BRANCH}'"
+  exit 0
+fi
+
+body=$(jq -r -c . <<EOF
+{
+  "title": "${COMMIT_TITLE}",
+  "head": "${BRANCH}",
+  "base": "${BASE_REF}",
+  "maintainer_can_modify": true
+}
+EOF
+)
+
+curl \
+  --fail \
+  --silent \
+  --request POST \
+  --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+  --header "Content-Type: application/json" \
+  --header "Accept: application/vnd.github.v3+json" \
+  --data "${body}" \
+  "https://api.github.com/repos/${REPOSITORY}/pulls"

--- a/github-actions/open_pr.sh
+++ b/github-actions/open_pr.sh
@@ -25,6 +25,7 @@ prs=$(
   curl \
     --fail \
     --request GET \
+    --header "Authorization: Bearer ${GITHUB_TOKEN}" \
     --header "Accept: application/vnd.github.v3+json" \
     "https://api.github.com/repos/${REPOSITORY}/pulls?state=open&head=${REPOSITORY_OWNER}:${BRANCH}" \
     | jq -r length

--- a/github-actions/open_pr.sh
+++ b/github-actions/open_pr.sh
@@ -16,6 +16,11 @@
 
 set -o errexit -o nounset -o pipefail
 
+# This script opens a PR if the provided branch is not currently being used as
+# the head of any other PR. If the branch is already the head, the general logic
+# is that the bot already opened a PR with this branch and the only necessary
+# step is to update the branch and push. If there are no PRs, the bot opens one.
+
 prs=$(
   curl \
     --fail \


### PR DESCRIPTION
Instead of pushing a commit directly to the pushed branch, open a PR.